### PR TITLE
[mbed-os-5.13.0] Adds NUCLEO_F303RE and DISCO_L475VG_IOT01A

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -8,6 +8,7 @@ int main() {
     while (true) {
         led1 = !led1;
         wait(0.5);
+        printf("hello, world\r\n");
     }
 }
 

--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#f4864dc6429e1ff5474111d4e0f6bee36a759b1c
+https://github.com/ARMmbed/mbed-os/

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -1,5 +1,9 @@
 {
     "target_overrides": {
+        "*": {
+            "target.features_add"      : ["BOOTLOADER", "STORAGE"],
+            "platform.stdio-baud-rate" : 115200
+        },
         "K64F": {
             "target.bootloader_img": "bootloader/K64F.bin"
         },
@@ -8,6 +12,16 @@
         },
         "UBLOX_EVK_ODIN_W2": {
             "target.bootloader_img": "bootloader/UBLOX_EVK_ODIN_W2.bin"
+        },
+        "NUCLEO_F303RE": {
+            "target.bootloader_img": "bootloader/NUCLEO_F303RE.bin",
+            "target.header_offset" : "0xD000",
+            "target.app_offset"    : "0xD400"
+        },
+        "DISCO_L475VG_IOT01A": {
+            "target.bootloader_img": "bootloader/DISCO_L475VG_IOT01A.bin",
+            "target.header_offset" : "0xD800",
+            "target.app_offset"    : "0xDC00"
         }
     }
 }

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -2,7 +2,9 @@
     "target_overrides": {
         "*": {
             "target.features_add"      : ["BOOTLOADER", "STORAGE"],
-            "platform.stdio-baud-rate" : 115200
+            "platform.stdio-baud-rate" : 115200,
+            "target.header_offset" : "0x10000",
+            "target.app_offset"    : "0x10400"
         },
         "K64F": {
             "target.bootloader_img": "bootloader/K64F.bin"
@@ -15,13 +17,19 @@
         },
         "NUCLEO_F303RE": {
             "target.bootloader_img": "bootloader/NUCLEO_F303RE.bin",
-            "target.header_offset" : "0xD000",
-            "target.app_offset"    : "0xD400"
+            "target.header_offset" : "0x11000",
+            "target.app_offset"    : "0x11400"
         },
         "DISCO_L475VG_IOT01A": {
             "target.bootloader_img": "bootloader/DISCO_L475VG_IOT01A.bin",
-            "target.header_offset" : "0xD800",
-            "target.app_offset"    : "0xDC00"
+            "target.header_offset" : "0x11000",
+            "target.app_offset"    : "0x11400"
+        },
+        "NRF52840_DK": {
+            "target.bootloader_img": "bootloader/NRF52840_DK.hex",
+            "target.header_offset" : "0x3B000",
+            "target.app_offset"    : "0x3B400",
+            "target.OUTPUT_EXT"    : "hex"
         }
     }
 }


### PR DESCRIPTION
Updates mbed-os to mbed-os-5.13.0

Created to test ARMmbed/mbed-bootloader-internal#184 , ARMmbed/mbed-bootloader-internal#187 and ARMmbed/mbed-bootloader-internal#188

### NUCLEO_F303RE
```
[BOOT] INFO: Initialize flash memory OK                                                                                                                                                                                                                                                                                                                                   

[BOOT] INFO: init - verified SFDP Signature and version Successfully                                                                                                                                                                                                                                                                                                      
[BOOT] DEBUG: Erase Type(A) 1 - Inst: 0xFFh, Size: 4096                                                                                                                                                                                                                                                                                                                   
[BOOT] INFO: Erase Type 1 - Inst: 0x20h, Size: 4096                                                                                                                                                                                                                                                                                                                       
[BOOT] DEBUG: Erase Type(A) 2 - Inst: 0xFFh, Size: 8192                                                                                                                                                                                                                                                                                                                   
[BOOT] INFO: Erase Type 2 - Inst: 0xD8h, Size: 8192                                                                                                                                                                                                                                                                                                                       
[BOOT] DEBUG: Erase Type(A) 3 - Inst: 0xFFh, Size: 32768                                                                                                                                                                                                                                                                                                                  
[BOOT] INFO: Erase Type 3 - Inst: 0xD8h, Size: 32768                                                                                                                                                                                                                                                                                                                      
[BOOT] DEBUG: Erase Type(A) 4 - Inst: 0xFFh, Size: 65536                                                                                                                                                                                                                                                                                                                  
[BOOT] INFO: Erase Type 4 - Inst: 0xD8h, Size: 65536                                                                                                                                                                                                                                                                                                                      
[BOOT] Mbed Bootloader                                                                                                                                                                                                                                                                                                                                                    
[BOOT] ARM: 00000000000000000000                                                                                                                                                                                                                                                                                                                                          
[BOOT] OEM: 00000000000000000000                                                                                                                                                                                                                                                                                                                                          
[BOOT] Layout: 0 8008208                                                                                                                                                                                                                                                                                                                                                  
[BOOT] Active firmware integrity check:                                                                                                                                                                                                                                                                                                                                   
[BOOT] [++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++]                                                                                                                                                                                                                                                                                           
[BOOT] SHA256: 1203B1AADCEB0B826930A86806F58FBBFB6FE861C3C59FE5A0E1C1A2ED5A3FA4                                                                                                                                                                                                                                                                                           
[BOOT] Version: 1561369741                                                                                                                                                                                                                                                                                                                                                
[BOOT] INFO Read - Inst: 0x3h                                                                                                                                                                                                                                                                                                                                             
[BOOT] Slot 0 is empty
[BOOT] Active firmware up-to-date
[BOOT] Application's start address: 0x800CC00
[BOOT] Application's jump address: 0x800FC79
[BOOT] Application's stack address: 0x20010000
[BOOT] Forwarding to application...
````

### DISCO_L475VG_IOT01A
```
[BOOT] Mbed Bootloader
[BOOT] ARM: 00000000000000000000
[BOOT] OEM: 00000000000000000000
[BOOT] Layout: 0 8008A78
[BOOT] Active firmware integrity check:
[BOOT] [++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++]
[BOOT] SHA256: FA095844D3F66BE9D15484DE515C33A0FF07F3E15776F01DACE4DB1162FD9E4B
[BOOT] Version: 1561370689
[BOOT] Slot 0 is empty
[BOOT] Active firmware up-to-date
[BOOT] Application's start address: 0x800D400
[BOOT] Application's jump address: 0x801095D
[BOOT] Application's stack address: 0x10000688
[BOOT] Forwarding to application...
```
